### PR TITLE
Maybe T of makeTemp() should be static?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.ignore
 
 *.cmake
 

--- a/GameConsole.tcc
+++ b/GameConsole.tcc
@@ -34,7 +34,7 @@ template <class T>
 inline T Virtuoso::GameConsole::makeTemp()
 {
 
-    T temp;
+    static T temp;
     return temp;
 
 }


### PR DESCRIPTION
I dont really know why, but if I don't put this var in static it gives me a runtime exeption when I use "sum" command or "sumFive"
`Run-Time Chech Failure #3 - The variable 'temp' is being used without being initialized`
but when I do it stops failing.
Whatch it and tell me please, I'll be glad to learn why or why don't.